### PR TITLE
default requests_options to {}

### DIFF
--- a/storedsafe/__init__.py
+++ b/storedsafe/__init__.py
@@ -52,7 +52,7 @@ class StoredSafe:
         if self.apikey is None:
             raise ApikeyUndefinedException()
 
-    def __headers(self, requests_options, token=True):
+    def __headers(self, requests_options={}, token=True):
         """Create the required headers for requests to the StoredSafe API and merge with options."""
         headers = {
             **self.requests_options.get('headers', {}),


### PR DESCRIPTION
When using the __headers function directly without adding any requests_options the function fails due to the missing options. Defaulting to empty dict circumvents this